### PR TITLE
Migrate to ChronoSim high-level sampler-spec interface

### DIFF
--- a/src/elevator/elevator.jl
+++ b/src/elevator/elevator.jl
@@ -14,7 +14,6 @@
 #
 module ElevatorExample
 using CompetingClocks
-using CompetingClocks: CombinedNextReaction
 using Distributions
 using Logging
 using Random
@@ -796,7 +795,6 @@ function run_elevator(; policy=ChronoSim.NoPolicy())
     floor_cnt = 3
     minutes = 120.0
     ClockKey=Tuple
-    Sampler = CombinedNextReaction{ClockKey,Float64}
     physical = ElevatorSystem(person_cnt, elevator_cnt, floor_cnt)
     included_transitions = [
         PickNewDestination,
@@ -812,8 +810,8 @@ function run_elevator(; policy=ChronoSim.NoPolicy())
     @assert length(included_transitions) == 9
     trajectory = TrajectorySave()
     sim = SimulationFSM(
-        physical, included_transitions; sampler=Sampler(), rng=Xoshiro(93472934),
-        observer=trajectory, policy=policy
+        physical, included_transitions; sampler=NextReactionMethod(), key_type=ClockKey,
+        rng=Xoshiro(93472934), observer=trajectory, policy=policy
     )
     trajectory.sim = sim
     # Stop-condition is called after the next event is chosen but before the

--- a/src/elevator/elevator_derived.jl
+++ b/src/elevator/elevator_derived.jl
@@ -39,7 +39,6 @@
 # keys and their trajectories compare directly. TLA recorder parts are not ported.
 module ElevatorDerivedExample
 using CompetingClocks
-using CompetingClocks: CombinedNextReaction
 using Distributions
 using Logging
 using Random
@@ -451,7 +450,6 @@ function run_elevator_derived()
     elevator_cnt = 1
     floor_cnt = 3
     minutes = 120.0
-    Sampler = CombinedNextReaction{Tuple,Float64}
     physical = ElevatorSystem(person_cnt, elevator_cnt, floor_cnt)
     included_transitions = [
         PickNewDestination,
@@ -466,7 +464,8 @@ function run_elevator_derived()
     ]
     @assert length(included_transitions) == 9
     sim = SimulationFSM(
-        physical, included_transitions; sampler=Sampler(), rng=Xoshiro(93472934)
+        physical, included_transitions; sampler=NextReactionMethod(), key_type=Tuple,
+        rng=Xoshiro(93472934)
     )
     stop_condition = function (physical, step_idx, event, when)
         return when > minutes

--- a/src/landspread/landspread.jl
+++ b/src/landspread/landspread.jl
@@ -2,7 +2,6 @@ module LandSpread
 
 using ChronoSim
 using CompetingClocks
-using CompetingClocks: CombinedNextReaction
 import ChronoSim: generators, precondition, enable, reenable, fire!
 using ChronoSim.ObservedState
 using Distributions
@@ -113,11 +112,11 @@ function landspread_likelihood(point_cnt)
     popfirst!(event_vector)  # Get rid of the InitializeEvent.
     rng = Xoshiro(9437294723)
     land = Landscape(point_cnt, rng)
-    sampler = CompetingClocks.MemorySampler(CombinedNextReaction{Tuple,Float64}())
     sim = SimulationFSM(
         land,
         [Spread];
-        sampler = sampler,
+        sampler = NextReactionMethod(), key_type = Tuple,
+        step_likelihood = true,
         rng = rng
         )
     how_likely = ChronoSim.trace_likelihood(sim, init_physical!, event_vector).loglikelihood

--- a/src/reliability/reliability.jl
+++ b/src/reliability/reliability.jl
@@ -2,7 +2,6 @@ module ReliabilitySim
 using ChronoSim
 using ChronoSim.ObservedState
 using CompetingClocks
-using CompetingClocks: CombinedNextReaction
 import ChronoSim: generators, precondition, enable, reenable, fire!
 using Distributions
 using Random
@@ -175,7 +174,6 @@ end
 
 function run_reliability(days)
     agent_cnt = 15
-    Sampler = CombinedNextReaction{Tuple,Float64}
     physical = IndividualState(agent_cnt, 10)
     included_transitions = [
         StartDay,
@@ -189,7 +187,7 @@ function run_reliability(days)
         included_transitions;
         rng=Xoshiro(2947223),
         observer=trajectory,
-        sampler=Sampler()
+        sampler=NextReactionMethod(), key_type=Tuple
     )
     initializer = function(init_physical, when, rng)
         initialize!(init_physical, rng)

--- a/src/reliability/reliability_derived.jl
+++ b/src/reliability/reliability_derived.jl
@@ -14,7 +14,6 @@ module ReliabilityDerivedSim
 using ChronoSim
 using ChronoSim.ObservedState
 using CompetingClocks
-using CompetingClocks: CombinedNextReaction
 import ChronoSim: generators, precondition, enable, reenable, fire!
 using Distributions
 using Random
@@ -157,14 +156,13 @@ end
 
 function run_reliability_derived(days)
     agent_cnt = 15
-    Sampler = CombinedNextReaction{Tuple,Float64}
     physical = IndividualState(agent_cnt, 10)
     included_transitions = [StartDay, EndDay, Break, Repair]
     sim = SimulationFSM(
         physical,
         included_transitions;
         rng=Xoshiro(2947223),
-        sampler=Sampler()
+        sampler=NextReactionMethod(), key_type=Tuple
     )
     initializer = function(init_physical, when, rng)
         initialize!(init_physical, rng)

--- a/test/test_differential.jl
+++ b/test/test_differential.jl
@@ -9,7 +9,6 @@
 
 using ChronoSim
 using CompetingClocks
-using CompetingClocks: CombinedNextReaction
 using Random
 using Test
 
@@ -51,7 +50,7 @@ function _reliability_trajectory(M; days=10.0, seed=2947223, oracle=false)
         physical,
         included;
         rng=Xoshiro(seed),
-        sampler=CombinedNextReaction{Tuple,Float64}(),
+        sampler=NextReactionMethod(), key_type=Tuple,
         observer=observer,
         policy=policy,
     )
@@ -81,7 +80,7 @@ function _elevator_trajectory(M; minutes=120.0, seed=93472934, oracle=false)
         physical,
         included;
         rng=Xoshiro(seed),
-        sampler=CombinedNextReaction{Tuple,Float64}(),
+        sampler=NextReactionMethod(), key_type=Tuple,
         observer=observer,
         policy=policy,
     )

--- a/test/test_invariants.jl
+++ b/test/test_invariants.jl
@@ -2,7 +2,6 @@ using ChronoSim
 using ChronoSim: module_invariants, CheckInvariants, InvariantViolation, PolicyStack,
     RecordSkeleton, clock_key, NoPolicy
 using CompetingClocks
-using CompetingClocks: CombinedNextReaction
 using Distributions
 using Logging
 using Random
@@ -84,7 +83,7 @@ end
     rec = RecordSkeleton()
     sim = SimulationFSM(
         physical, transitions;
-        sampler=CombinedNextReaction{Tuple,Float64}(), rng=Xoshiro(93472934),
+        sampler=NextReactionMethod(), key_type=Tuple, rng=Xoshiro(93472934),
         policy=PolicyStack(rec, CheckInvariants(ElevatorExample)),
     )
     stop = (p, i, e, w) -> w > 120.0

--- a/test/test_overapprox.jl
+++ b/test/test_overapprox.jl
@@ -8,7 +8,6 @@
 
 using ChronoSim
 using CompetingClocks
-using CompetingClocks: CombinedNextReaction
 using Random
 using Test
 
@@ -38,7 +37,7 @@ function _run_reliability(M; days=10.0, seed=2947223)
         physical,
         included;
         rng=Xoshiro(seed),
-        sampler=CombinedNextReaction{Tuple,Float64}(),
+        sampler=NextReactionMethod(), key_type=Tuple,
     )
     initializer = (init_physical, when, rng) -> M.initialize!(init_physical, rng)
     stop_condition = (p, step_idx, event, when) -> when > days
@@ -63,7 +62,7 @@ function _run_elevator(M; minutes=120.0, seed=93472934)
         physical,
         included;
         rng=Xoshiro(seed),
-        sampler=CombinedNextReaction{Tuple,Float64}(),
+        sampler=NextReactionMethod(), key_type=Tuple,
     )
     stop_condition = (p, step_idx, event, when) -> when > minutes
     ChronoSim.run(sim, M.init_physical, stop_condition)

--- a/test/test_quint.jl
+++ b/test/test_quint.jl
@@ -7,7 +7,7 @@
 using ChronoSim
 using ChronoSim: compile_quint, validate_trace, QuintCompileError, find_quint_toolchain
 using Random
-using CompetingClocks: CombinedNextReaction
+using CompetingClocks: NextReactionMethod
 import ChronoSim
 
 const _QTC = find_quint_toolchain()
@@ -99,7 +99,7 @@ end
 function _elev_factory(policy)
     E = _QElev.E
     phys = E.ElevatorSystem(3, 2, 5)
-    sim = SimulationFSM(phys, _QElev.EVENTS; sampler=CombinedNextReaction{Tuple,Float64}(),
+    sim = SimulationFSM(phys, _QElev.EVENTS; sampler=NextReactionMethod(), key_type=Tuple,
         rng=Xoshiro(93472934), policy=policy)
     (sim, E.init_physical)
 end

--- a/test/test_replay_examples.jl
+++ b/test/test_replay_examples.jl
@@ -7,7 +7,6 @@
 using ChronoSim
 using ChronoSim: ProbePolicy
 using CompetingClocks
-using CompetingClocks: CombinedNextReaction
 using Random
 using Test
 using Logging
@@ -28,7 +27,7 @@ function _record_elevator(; person=1, elevator=1, floors=3, minutes=120.0, seed=
     physical = ED.ElevatorSystem(person, elevator, floors)
     rec = RecordSkeleton(; metadata=(model="elevator", seed=seed))
     sim = SimulationFSM(physical, _ELEV_EVENTS;
-        sampler=CombinedNextReaction{Tuple,Float64}(), rng=Xoshiro(seed), policy=rec)
+        sampler=NextReactionMethod(), key_type=Tuple, rng=Xoshiro(seed), policy=rec)
     stop = (p, i, e, w) -> w > minutes
     ChronoSim.run(sim, ED.init_physical, stop)
     return recorded_skeleton(rec)
@@ -37,7 +36,7 @@ end
 function _elevator_factory(policy; person=1, elevator=1, floors=3, seed=93472934)
     physical = ED.ElevatorSystem(person, elevator, floors)
     sim = SimulationFSM(physical, _ELEV_EVENTS;
-        sampler=CombinedNextReaction{Tuple,Float64}(), rng=Xoshiro(seed), policy=policy)
+        sampler=NextReactionMethod(), key_type=Tuple, rng=Xoshiro(seed), policy=policy)
     return (sim, ED.init_physical)
 end
 

--- a/test/test_skeleton.jl
+++ b/test/test_skeleton.jl
@@ -5,7 +5,6 @@
 
 using ChronoSim
 using CompetingClocks
-using CompetingClocks: CombinedNextReaction
 using Random
 using Test
 using Logging

--- a/test/test_whyverbs.jl
+++ b/test/test_whyverbs.jl
@@ -13,7 +13,6 @@ using ChronoSim: InvariantViolation, CheckInvariants, PolicyStack, RecordSkeleto
     recorded_skeleton, clock_key
 using ChronoSim.ObservedState
 using CompetingClocks
-using CompetingClocks: CombinedNextReaction
 using Distributions
 using Logging
 using Random
@@ -39,7 +38,7 @@ _elev_events(M) = [M.PickNewDestination, M.CallElevator, M.OpenElevatorDoors,
     # (a) The unmodified derived twin: discover the first StopElevator step.
     recd = RecordSkeleton()
     simd = SimulationFSM(_ED.ElevatorSystem(P, E, F), _elev_events(_ED);
-        sampler=CombinedNextReaction{Tuple,Float64}(), rng=Xoshiro(seed), policy=recd)
+        sampler=NextReactionMethod(), key_type=Tuple, rng=Xoshiro(seed), policy=recd)
     ChronoSim.run(simd, _ED.init_physical, (p, i, e, w) -> w > 120.0)
     skeld = recorded_skeleton(recd)
     s = findfirst(st -> st.clock[1] == :StopElevator, skeld.steps)
@@ -51,11 +50,11 @@ _elev_events(M) = [M.PickNewDestination, M.CallElevator, M.OpenElevatorDoors,
     # precondition holds there by construction, yet nothing ever proposed it.
     recb = RecordSkeleton()
     simb = SimulationFSM(_SB.ElevatorSystem(P, E, F), _elev_events(_SB);
-        sampler=CombinedNextReaction{Tuple,Float64}(), rng=Xoshiro(seed), policy=recb)
+        sampler=NextReactionMethod(), key_type=Tuple, rng=Xoshiro(seed), policy=recb)
     ChronoSim.run(simb, _SB.init_physical, (p, i, e, w) -> i >= s)
     skelb = recorded_skeleton(recb)
     factory = policy -> (SimulationFSM(_SB.ElevatorSystem(P, E, F), _elev_events(_SB);
-        sampler=CombinedNextReaction{Tuple,Float64}(), rng=Xoshiro(seed), policy=policy),
+        sampler=NextReactionMethod(), key_type=Tuple, rng=Xoshiro(seed), policy=policy),
         _SB.init_physical)
 
     rep = whynot(skelb, factory, _SB.StopElevator(k))
@@ -79,7 +78,7 @@ end
     seed = 93472934
     rec = RecordSkeleton()
     sim = SimulationFSM(_NB.ElevatorSystem(1, 2, 5), _elev_events(_NB);
-        sampler=CombinedNextReaction{Tuple,Float64}(), rng=Xoshiro(seed), policy=rec)
+        sampler=NextReactionMethod(), key_type=Tuple, rng=Xoshiro(seed), policy=rec)
     ChronoSim.run(sim, _NB.init_physical, (p, i, e, w) -> w > 60.0)
     skel = recorded_skeleton(rec)
 
@@ -95,7 +94,7 @@ end
     k_other = 3 - k_open
 
     factory = policy -> (SimulationFSM(_NB.ElevatorSystem(1, 2, 5), _elev_events(_NB);
-        sampler=CombinedNextReaction{Tuple,Float64}(), rng=Xoshiro(seed), policy=policy),
+        sampler=NextReactionMethod(), key_type=Tuple, rng=Xoshiro(seed), policy=policy),
         _NB.init_physical)
 
     rep = whynot(skel, factory, _NB.OpenElevatorDoors(k_other))
@@ -185,7 +184,7 @@ end # module
     transitions = vcat(_elev_events(ElevatorExample), WhyVerbsCorrupt.CorruptPerson)
     rec = RecordSkeleton()
     sim = SimulationFSM(physical, transitions;
-        sampler=CombinedNextReaction{Tuple,Float64}(), rng=Xoshiro(93472934),
+        sampler=NextReactionMethod(), key_type=Tuple, rng=Xoshiro(93472934),
         policy=PolicyStack(rec, CheckInvariants(ElevatorExample)))
     err = try
         with_logger(ConsoleLogger(stderr, Logging.Warn)) do

--- a/test/whyverbs_elevator_nobutton.jl
+++ b/test/whyverbs_elevator_nobutton.jl
@@ -50,7 +50,6 @@
 # keys and their trajectories compare directly. TLA recorder parts are not ported.
 module ElevatorNoButton
 using CompetingClocks
-using CompetingClocks: CombinedNextReaction
 using Distributions
 using Logging
 using Random
@@ -462,7 +461,6 @@ function run_elevator_derived()
     elevator_cnt = 1
     floor_cnt = 3
     minutes = 120.0
-    Sampler = CombinedNextReaction{Tuple,Float64}
     physical = ElevatorSystem(person_cnt, elevator_cnt, floor_cnt)
     included_transitions = [
         PickNewDestination,
@@ -477,7 +475,8 @@ function run_elevator_derived()
     ]
     @assert length(included_transitions) == 9
     sim = SimulationFSM(
-        physical, included_transitions; sampler=Sampler(), rng=Xoshiro(93472934)
+        physical, included_transitions; sampler=NextReactionMethod(), key_type=Tuple,
+        rng=Xoshiro(93472934)
     )
     stop_condition = function (physical, step_idx, event, when)
         return when > minutes

--- a/test/whyverbs_elevator_stopbug.jl
+++ b/test/whyverbs_elevator_stopbug.jl
@@ -15,7 +15,6 @@
 #
 module ElevatorStopBug
 using CompetingClocks
-using CompetingClocks: CombinedNextReaction
 using Distributions
 using Logging
 using Random
@@ -776,7 +775,6 @@ function run_elevator(; policy=ChronoSim.NoPolicy())
     floor_cnt = 3
     minutes = 120.0
     ClockKey=Tuple
-    Sampler = CombinedNextReaction{ClockKey,Float64}
     physical = ElevatorSystem(person_cnt, elevator_cnt, floor_cnt)
     included_transitions = [
         PickNewDestination,
@@ -792,8 +790,8 @@ function run_elevator(; policy=ChronoSim.NoPolicy())
     @assert length(included_transitions) == 9
     trajectory = TrajectorySave()
     sim = SimulationFSM(
-        physical, included_transitions; sampler=Sampler(), rng=Xoshiro(93472934),
-        observer=trajectory, policy=policy
+        physical, included_transitions; sampler=NextReactionMethod(), key_type=ClockKey,
+        rng=Xoshiro(93472934), observer=trajectory, policy=policy
     )
     trajectory.sim = sim
     # Stop-condition is called after the next event is chosen but before the


### PR DESCRIPTION
## Summary

ChronoSim.jl was updated so that `SimulationFSM` owns the rng and builds the `SamplingContext` itself. The `sampler` keyword now takes a **method spec** (e.g. `NextReactionMethod()`) plus a `key_type`, rather than a sampler **instance**. Before this change the whole test suite failed on the first test with an `ArgumentError` from the constructor.

This migrates every call site in the example models and tests to the new interface.

## Changes

- Replace `sampler=CombinedNextReaction{K,Float64}()` → `sampler=NextReactionMethod(), key_type=K` across the 5 source models and 8 test files (including the `Sampler = CombinedNextReaction{...}` local-variable pattern).
- `landspread_likelihood`: the old `MemorySampler(CombinedNextReaction{...}())` wrapper (which enabled likelihood tracking) becomes `sampler=NextReactionMethod(), key_type=Tuple, step_likelihood=true` — `step_likelihood=true` is what `trace_likelihood` now requires.
- Drop the now-unused `CombinedNextReaction` imports; `test_quint.jl` (which had no bare `using CompetingClocks`) has its import swapped to `NextReactionMethod`.

## Testing

- `Pkg.test()` — full suite passes.
- Exercised the untested `landspread_likelihood` demo directly to confirm it runs cleanly through the new interface. It prints `logpdf 0.0` because `run_landspread` produces only the InitializeEvent and no Spread events — pre-existing example behavior (it uses the default sampler, unchanged here), not a regression from this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)