### PR TITLE
Fix GitHub CI: repoint deleted ChronoSim branch and repair the docs job

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -120,9 +120,10 @@ jobs:
           CHRONOSIM_QUINT: ${{ github.workspace }}/quint-tools
   docs:
     name: Documentation
-    # The docs environment instantiates the path-dev Manifest, which only
-    # resolves on main's registered dependency graph; the integration branch
-    # gets the test job alone.
+    # ChronoSim/CompetingClocks are unregistered path deps, so — like the test
+    # job — the siblings are checked out and re-developed by path. Both the root
+    # project (julia-buildpkg) and the docs project (docdeploy + doctests) need
+    # them, so develop into each. Runs on main only, where DOCUMENTER_KEY exists.
     if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     permissions:
@@ -131,15 +132,35 @@ jobs:
       statuses: write
     steps:
       - uses: actions/checkout@v6
+      - uses: actions/checkout@v6
+        with:
+          repository: adolgert/ChronoSim.jl
+          ref: main
+          path: deps/ChronoSim.jl
+      - uses: actions/checkout@v6
+        with:
+          repository: adolgert/CompetingClocks.jl
+          path: deps/CompetingClocks.jl
       - uses: julia-actions/setup-julia@v2
         with:
           version: '1'
       - uses: julia-actions/cache@v2
-      - name: Configure doc environment
-        shell: julia --project=docs --color=yes {0}
+      - name: Develop sibling dependencies (root + docs environments)
+        shell: julia --color=yes {0}
         run: |
           using Pkg
-          Pkg.develop(PackageSpec(path=pwd()))
+          siblings = [
+              PackageSpec(path="deps/CompetingClocks.jl"),
+              PackageSpec(path="deps/ChronoSim.jl"),
+          ]
+          # Root project: julia-buildpkg instantiates it.
+          Pkg.activate(".")
+          Pkg.develop(siblings)
+          # Docs project depends on ChronoSimExamples (unregistered), so develop
+          # it together with the siblings in one call — otherwise resolving the
+          # siblings alone fails on the not-yet-developed package.
+          Pkg.activate("docs")
+          Pkg.develop(vcat(siblings, [PackageSpec(path=".")]))
           Pkg.instantiate()
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-docdeploy@v1

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -42,7 +42,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           repository: adolgert/ChronoSim.jl
-          ref: dev/verification
+          ref: main
           path: deps/ChronoSim.jl
       - uses: actions/checkout@v6
         with:
@@ -79,7 +79,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           repository: adolgert/ChronoSim.jl
-          ref: dev/verification
+          ref: main
           path: deps/ChronoSim.jl
       - uses: actions/checkout@v6
         with:

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -15,6 +15,11 @@ makedocs(;
     pages=[
         "Home" => "index.md",
     ],
+    # The example models live in submodules (ElevatorExample, SIRVillage, ...)
+    # whose per-event docstrings are not meant to be enumerated in the manual;
+    # the top-level @autodocs block covers the package's own bindings. Keep the
+    # missing-docstring check as a warning rather than a hard build failure.
+    warnonly=[:missing_docs],
 )
 
 deploydocs(;


### PR DESCRIPTION
## Problem

CI has been red on every run since ChronoSim.jl's `dev/verification` branch was merged into its `main` (PR #32, the SamplingContext migration) and **deleted from the remote**. Both the `test` and `model-check` jobs checked out `adolgert/ChronoSim.jl` at `ref: dev/verification`, so `actions/checkout` hard-failed fetching a nonexistent ref — the jobs died in ~40s during checkout, before Julia even started. Separately, the main-only `docs` job had never built.

## Root cause

- **`test` / `model-check`**: `ref: dev/verification` no longer exists. `main` (76c2bfd) is a strict superset of it (fully merged) **and** carries the new high-level sampler interface these examples now target.
- **`docs`**: (1) it never checked out the unregistered `ChronoSim`/`CompetingClocks` path deps, so neither the root project (`julia-buildpkg`) nor the docs project (`docdeploy`/doctests) could resolve; (2) Documenter's `missing_docs` check is fatal by default, and the example submodules carry per-event docstrings deliberately kept out of the manual.

## Changes

- Point the ChronoSim.jl checkout at `main` in the `test` and `model-check` jobs.
- `docs` job: check out both siblings at `main` and develop them by path into **both** the root and docs environments (docs develops the package + siblings in one call so resolution sees every path dep at once).
- `docs/make.jl`: `warnonly=[:missing_docs]` so submodule docstrings warn instead of failing the build.

## Verification

Reproduced CI's exact develop-by-path + instantiate flow against **ChronoSim main + CompetingClocks main (0.3.1)** in isolated projects:

- `test` job: full `Pkg.test()` passes (Quint toolchain-gated testsets show as broken/skipped, as expected without the toolchain).
- `docs` job: the develop/instantiate, root `buildpkg`, `make.jl` render, and `doctest` steps all exit clean; the single doctest passes.

Note: this repo tracks ChronoSim/CompetingClocks `main` by path, so the examples CI now follows those moving branches — matching the local dev workflow where all three are developed together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)