### PR TITLE
WorldTimer adoption: repair-shop gradients and CompetingClocks 0.4 / ChronoSim parameter-seam migration

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,0 +1,188 @@
+# Migrating models to ChronoSim (worldtimer-adoption) and CompetingClocks 0.4
+
+This package's five example models were migrated to the `worldtimer-adoption`
+branches of [ChronoSim.jl](https://github.com/adolgert/ChronoSim.jl) and
+[CompetingClocks.jl](https://github.com/adolgert/CompetingClocks.jl)
+(CompetingClocks version 0.4.0, a breaking release). This document lists what a
+model author has to change, ordered from most likely to least likely. Every
+before/after snippet is drawn from an actual fix made in this repository.
+
+## Summary of what changed upstream
+
+CompetingClocks 0.4.0 moved ownership of randomness into the sampler: the
+sampler verbs (`enable!`, `next`, `fire!`, ...) no longer take a random number
+generator argument. Instead, each clock key owns a dedicated random stream,
+seeded deterministically from one master seed via `hash((seed, clock_key))`.
+`clone` now means "full-state coupled copy" (the old empty-copy behavior is
+`similar_sampler`), and the `CommonRandom` common-random-numbers subsystem was
+removed because keyed streams subsume it. ChronoSim gained the θ (parameter)
+seam — a four-argument `enable(event, physical, θ, when)` — plus per-event
+re-evaluation and memory declarations, a `MinimalRecord` trajectory record with
+an exact-replay `effect_check`, `clone`/`force_fire!` for branching estimators,
+and opt-in read verification. ChronoSim's own randomness is likewise derived
+from a single master seed.
+
+## 1. Most models: change nothing but a compat bound
+
+If your model talks only to ChronoSim's documented surface — `SimulationFSM`,
+`precondition`/`enable`/`fire!`, `@conditionsfor`, `ChronoSim.run`,
+`trace_likelihood` — it compiles and runs unchanged. The verb-level breaking
+change in CompetingClocks 0.4 is absorbed entirely below ChronoSim's
+`SamplingContext`. All five models in this package (elevator, reliability,
+sirvillage, landspread, and their derived twins) needed **zero** signature
+changes. The only mandatory edit was the compat bound:
+
+```toml
+# Project.toml, before
+CompetingClocks = "0.3"
+
+# after
+CompetingClocks = "0.4"
+```
+
+The old three-argument `enable(event, physical, when)` keeps working: the
+engine calls the four-argument form, and its default method forwards to yours.
+`src/reliability/reliability.jl` deliberately keeps the three-argument
+signature as standing evidence of that fallback.
+
+## 2. Seeded trajectories differ; re-pin golden outputs
+
+A `SimulationFSM` built with `rng=Xoshiro(seed)` or `seed=` now derives one
+master seed and seeds every per-clock stream from it, so **the same seed
+produces a different (equally valid) trajectory than it did before**. Any test
+that pins concrete event times or event orders from a seeded run needs its
+literals re-captured once, with a comment saying why. Statistical assertions
+and structural identities are stream-layout independent and should pass
+unchanged — in this package, no re-pin was needed at all, because the tests
+assert identities (hand-written and derived twins produce the same trajectory,
+derived generators propose a superset, admissions are equal) rather than
+literal times.
+
+The compensation for re-pinning is a much stronger reproducibility property:
+an event's draws now belong to that event's clock key, so two same-seed runs
+give each event identical randomness even when other events interleave
+differently.
+
+## 3. Clock keys must hash content-stably (the enum trap)
+
+This was the one real breakage in this package, and it broke three test files
+at once. CompetingClocks 0.4 seeds each clock's stream from
+`hash((seed, clock_key))`. A clock key component with no content-based
+`Base.hash` method falls back to `objectid` hashing, which is neither stable
+across Julia processes with different compile options (a plain
+`julia --project` run and a `Pkg.test` run disagreed) nor equal across two
+modules that define the "same" `@enum`. The elevator's `DispatchElevator`
+event carries a direction enum in its clock key, so its firing times were not
+reproducible, and the hand-written and derived twin modules — whose
+trajectories must be identical — silently diverged.
+
+The fix is one line per enum, in the module that owns the enum (this is a
+method on your own type, not type piracy):
+
+```julia
+# before: clock streams seeded from objectid-based hashes — unstable
+@enum ElevatorDirection Up Down Stationary
+
+# after: content-based hash, stable across processes and modules
+@enum ElevatorDirection Up Down Stationary
+Base.hash(x::ElevatorDirection, h::UInt) = hash(Symbol(x), h)
+```
+
+Rule of thumb: every component of every clock key should be a `Symbol`, an
+integer, a string, or a type that defines a content-based `Base.hash`. Audit
+your event structs' fields, because `clock_key(event)` is built from them.
+
+## 4. `CommonRandom` is gone; keyed streams are the successor
+
+This package never used `CommonRandom`, so nothing here needed rewriting, but
+for models that did: the coupling it provided is now structural. Two samplers
+built from the same seed give the same clock key the same draws, by
+construction, no recording or replay machinery required:
+
+```julia
+# Coupled pair for a finite-difference: same seed, different θ.
+sim_lo = SimulationFSM(build_state(), events; seed=42, params=[θ])
+sim_hi = SimulationFSM(build_state(), events; seed=42, params=[θ + h])
+# Clocks shared by the two runs consume identical per-(key, occurrence) draws.
+```
+
+To make a cloned simulation diverge on purpose, rekey its streams
+(`CompetingClocks.rekey_streams!`); divergence is now an explicit act rather
+than a side effect of passing a different generator. See the CompetingClocks
+documentation on keyed streams for the coupling guarantees, and ChronoSim's
+`clone(sim)`/`force_fire!` for branching workflows built on top of them.
+
+## 5. Hand-rolled `@obswrite` state: a fixed bug worth knowing about
+
+This is a pre-existing bug that the migration audit surfaced, relevant only to
+models that implement `ObservedPhysical` by hand with `@obsread`/`@obswrite`
+(models using `@observedphysical` containers are unaffected). The assignment
+form of `@obswrite` recorded the written address but **discarded the
+right-hand side**, so the write silently never happened. The landspread
+example ran zero events because of this. The macro is **fixed on ChronoSim's
+`worldtimer-adoption` branch** (the assignment now executes, with a
+regression test asserting the value actually changes), so the assignment form
+is safe against that branch and later releases. The separated form used by
+this package's landspread example remains equally valid:
+
+```julia
+# before: records the address, silently drops the assignment
+@fire function fire!(evt::Spread, land, when, rng)
+    @obswrite land.mark[evt.destination] = 1
+end
+
+# after: assign, then record
+@fire function fire!(evt::Spread, land, when, rng)
+    land.mark[evt.destination] = 1
+    @obswrite land.mark[evt.destination]
+end
+```
+
+If your model has no functional test that asserts events actually fire, add
+one; that absence is what let this example stay silently dead
+(`test/test_landspread.jl` now pins it).
+
+## 6. New capabilities worth adopting (optional)
+
+None of these are required, but each is demonstrated working in this package:
+
+* **The θ seam.** Read parameters from an explicit vector in a four-argument
+  `enable`, and evaluate a recorded trace at any θ — including ForwardDiff
+  dual numbers — via `trace_likelihood(sim, init, trace; params=θ)`. See
+  `src/landspread/landspread.jl` for the model-side change:
+
+  ```julia
+  # before: parameters hard-coded in the model
+  function enable(evt::Spread, land, when)
+      scale = 0.1 * land.distance[evt.source, evt.destination]^1.2
+      return (Weibull(2, scale), when)
+  end
+
+  # after: parameters read from θ at the seam
+  function enable(evt::Spread, land, θ, when)
+      scale = θ[1] * land.distance[evt.source, evt.destination]^θ[2]
+      return (Weibull(2, scale), when)
+  end
+  ```
+
+* **Records and the effect check.** Run with `policy=RecordMinimal(...)` to
+  capture a `MinimalRecord`, then `effect_check` replays it and demands exact
+  floating-point equality with the forward log-likelihood. See
+  `src/repairshop/repairshop.jl` for the full record → check → differentiate
+  workflow, including horizon-censored evaluation (`censor=true`).
+
+* **Per-event declarations.** `reevaluation_coupling(::Type{MyEvent}) = :carry`
+  declares the IPA-safe coupling for a still-enabled clock whose distribution
+  is re-evaluated (`:redraw` is the default and matches prior behavior for
+  models whose `reenable` never changes the schedule);
+  `memory_policy(::Type{MyEvent}) = :resume` banks a clock's age across
+  disable/enable cycles. See ChronoSim's documentation for both.
+
+* **Cloning and forced firing.** `clone(sim)` produces a coupled, independent
+  copy of a running simulation; `force_fire!(sim, key, t)` imposes a chosen
+  transition at a chosen time through the same update path as a natural
+  firing. These are the primitives for weak-derivative branching estimators.
+
+* **Read verification.** `ChronoSim.with_read_verification(f)` (or
+  `check_derivation_coverage`) audits that derived triggers cover every place
+  a precondition reads; this package's differential tests run under it.

--- a/Manifest.toml
+++ b/Manifest.toml
@@ -2,7 +2,7 @@
 
 julia_version = "1.12.5"
 manifest_format = "2.0"
-project_hash = "73431148b77ccafeada440f1f900f2a86cea8552"
+project_hash = "9b863538a71146709706a74d11fb9528bdd07277"
 
 [[deps.Accessors]]
 deps = ["CompositionsBase", "ConstructionBase", "Dates", "InverseFunctions", "MacroTools"]
@@ -55,11 +55,21 @@ git-tree-sha1 = "99ee296f88c12485402e37c2fd025f95ae097637"
 uuid = "38540f10-b2f7-11e9-35d8-d573e4eb0ff2"
 version = "0.2.9"
 
+[[deps.CommonSubexpressions]]
+deps = ["MacroTools"]
+git-tree-sha1 = "cda2cfaebb4be89c9084adaca7dd7333369715c5"
+uuid = "bbf7d656-a473-5ed7-a52c-81e309532950"
+version = "0.3.1"
+
 [[deps.CompetingClocks]]
 deps = ["DataStructures", "Distributions", "Logging", "Random"]
 path = "../CompetingClocks.jl"
 uuid = "5bb9b785-358c-4fee-af0f-b94a146244a8"
-version = "0.3.0"
+version = "0.4.0"
+weakdeps = ["ForwardDiff"]
+
+    [deps.CompetingClocks.extensions]
+    CompetingClocksForwardDiffExt = "ForwardDiff"
 
 [[deps.CompilerSupportLibraries_jll]]
 deps = ["Artifacts", "Libdl"]
@@ -106,6 +116,18 @@ deps = ["Printf"]
 uuid = "ade2ca70-3891-5945-98fb-dc099432e06a"
 version = "1.11.0"
 
+[[deps.DiffResults]]
+deps = ["StaticArraysCore"]
+git-tree-sha1 = "782dd5f4561f5d267313f23853baaaa4c52ea621"
+uuid = "163ba53b-c6d8-5494-b064-1a9d43ac40c5"
+version = "1.1.0"
+
+[[deps.DiffRules]]
+deps = ["IrrationalConstants", "LogExpFunctions", "NaNMath", "Random", "SpecialFunctions"]
+git-tree-sha1 = "79a2aca180a85c690c58a020d47b426954b590f8"
+uuid = "b552c78f-8df3-52c6-915a-8e097449b14b"
+version = "1.16.0"
+
 [[deps.Distributions]]
 deps = ["AliasTables", "FillArrays", "LinearAlgebra", "PDMats", "Printf", "QuadGK", "Random", "Roots", "SpecialFunctions", "Statistics", "StatsAPI", "StatsBase", "StatsFuns"]
 git-tree-sha1 = "cd3c5ac74cd3923c8945c6a81518c46abd0e73a3"
@@ -146,6 +168,18 @@ version = "1.16.0"
     SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
     StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
     Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
+
+[[deps.ForwardDiff]]
+deps = ["CommonSubexpressions", "DiffResults", "DiffRules", "LinearAlgebra", "LogExpFunctions", "NaNMath", "Preferences", "Printf", "Random", "SpecialFunctions"]
+git-tree-sha1 = "2c5d0b0e12088cde2cf84afb2784415b1ea3dfee"
+uuid = "f6369f11-7733-5829-9624-2563aa707210"
+version = "1.4.1"
+
+    [deps.ForwardDiff.extensions]
+    ForwardDiffStaticArraysExt = "StaticArrays"
+
+    [deps.ForwardDiff.weakdeps]
+    StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 
 [[deps.Gamma]]
 git-tree-sha1 = "86f86b6168a016ed88e4ae4e64577b98c3b59e8e"
@@ -221,6 +255,12 @@ deps = ["DataAPI"]
 git-tree-sha1 = "ec4f7fbeab05d7747bdf98eb74d130a2a2ed298d"
 uuid = "e1d29d7a-bbdc-5cf2-9ac0-f12de2c33e28"
 version = "1.2.0"
+
+[[deps.NaNMath]]
+deps = ["OpenLibm_jll"]
+git-tree-sha1 = "dbd2e8cd2c1c27f0b584f6661b4309609c5a685e"
+uuid = "77ba4419-2d1f-58cd-9bb1-8ffee604a2e3"
+version = "1.1.4"
 
 [[deps.OpenBLAS_jll]]
 deps = ["Artifacts", "CompilerSupportLibraries_jll", "Libdl"]
@@ -355,6 +395,11 @@ version = "2.8.0"
 
     [deps.SpecialFunctions.weakdeps]
     ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
+
+[[deps.StaticArraysCore]]
+git-tree-sha1 = "6ab403037779dae8c514bad259f32a447262455a"
+uuid = "1e83bf80-4336-4d27-bf5d-d5a4f845583c"
+version = "1.4.4"
 
 [[deps.Statistics]]
 deps = ["LinearAlgebra"]

--- a/Manifest.toml
+++ b/Manifest.toml
@@ -1,8 +1,8 @@
 # This file is machine-generated - editing it directly is not advised
 
-julia_version = "1.12.5"
+julia_version = "1.12.6"
 manifest_format = "2.0"
-project_hash = "9b863538a71146709706a74d11fb9528bdd07277"
+project_hash = "76457c25f864c3c20889cd078881899716378e69"
 
 [[deps.Accessors]]
 deps = ["CompositionsBase", "ConstructionBase", "Dates", "InverseFunctions", "MacroTools"]
@@ -45,10 +45,20 @@ uuid = "3d4a2042-d4c0-4032-96bb-6b9d4a3cae87"
 version = "0.1.0-DEV"
 
 [[deps.ChronoSimExamples]]
-deps = ["ChronoSim", "CompetingClocks", "Distributions", "Logging", "PDMats", "Random"]
+deps = ["ChronoSim", "ClockGradients", "CompetingClocks", "Distributions", "ForwardDiff", "Logging", "PDMats", "Random"]
 path = "."
 uuid = "1bc6675e-297e-45c4-9a4f-4c2ceebb3e92"
 version = "1.0.0-DEV"
+
+[[deps.ClockGradients]]
+deps = ["CompetingClocks", "Distributions", "ForwardDiff", "Random", "Statistics"]
+path = "../ClockGradients.jl"
+uuid = "4ce9755b-dddc-4f69-a7df-9a3441b90f10"
+version = "0.1.0-DEV"
+weakdeps = ["ChronoSim"]
+
+    [deps.ClockGradients.extensions]
+    ClockGradientsChronoSimExt = "ChronoSim"
 
 [[deps.CommonSolve]]
 git-tree-sha1 = "99ee296f88c12485402e37c2fd025f95ae097637"
@@ -65,7 +75,7 @@ version = "0.3.1"
 deps = ["DataStructures", "Distributions", "Logging", "Random"]
 path = "../CompetingClocks.jl"
 uuid = "5bb9b785-358c-4fee-af0f-b94a146244a8"
-version = "0.4.0"
+version = "0.4.1"
 weakdeps = ["ForwardDiff"]
 
     [deps.CompetingClocks.extensions]

--- a/Project.toml
+++ b/Project.toml
@@ -1,19 +1,21 @@
 name = "ChronoSimExamples"
 uuid = "1bc6675e-297e-45c4-9a4f-4c2ceebb3e92"
-authors = ["Andrew Dolgert <github@dolgert.com>"]
 version = "1.0.0-DEV"
+authors = ["Andrew Dolgert <github@dolgert.com>"]
 
 [deps]
 ChronoSim = "3d4a2042-d4c0-4032-96bb-6b9d4a3cae87"
 CompetingClocks = "5bb9b785-358c-4fee-af0f-b94a146244a8"
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
+ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
 Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"
 PDMats = "90014a1f-27ba-587c-ab20-58faa44d9150"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 
 [compat]
-CompetingClocks = "0.3"
+CompetingClocks = "0.4"
 Distributions = "0.25.120"
+ForwardDiff = "1.4.1"
 Logging = "1.11.0"
 PDMats = "0.11.35"
 Random = "1.11.0"

--- a/Project.toml
+++ b/Project.toml
@@ -5,6 +5,7 @@ authors = ["Andrew Dolgert <github@dolgert.com>"]
 
 [deps]
 ChronoSim = "3d4a2042-d4c0-4032-96bb-6b9d4a3cae87"
+ClockGradients = "4ce9755b-dddc-4f69-a7df-9a3441b90f10"
 CompetingClocks = "5bb9b785-358c-4fee-af0f-b94a146244a8"
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
 ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"

--- a/README.md
+++ b/README.md
@@ -4,7 +4,60 @@
 [![Dev](https://img.shields.io/badge/docs-dev-blue.svg)](https://adolgert.github.io/ChronoSimExamples.jl/dev/)
 [![Build Status](https://github.com/adolgert/ChronoSimExamples.jl/actions/workflows/CI.yml/badge.svg?branch=main)](https://github.com/adolgert/ChronoSimExamples.jl/actions/workflows/CI.yml?query=branch%3Amain)
 
-This repository has examples of simulations written with [ChronoSim.jl](https://github.com/adolgert/ChronoSim.jl).
+This repository has examples of simulations written with
+[ChronoSim.jl](https://github.com/adolgert/ChronoSim.jl), which samples its
+continuous-time events with
+[CompetingClocks.jl](https://github.com/adolgert/CompetingClocks.jl).
 
  * [Bank of multiple elevators](src/elevator/elevator.jl)
- * [Reliability of set of trucks](src/reliability/reliability.jl)
+ * [Reliability of a set of trucks](src/reliability/reliability.jl)
+ * [Spread across a landscape](src/landspread/landspread.jl)
+ * [Machine repair shop with a differentiable likelihood](src/repairshop/repairshop.jl)
+ * [Village-scale epidemic](src/sirvillage/sirvillage.jl)
+
+Several models come in pairs: a hand-written module and a "derived twin" whose
+event triggers are generated from the event preconditions by ChronoSim's
+derivation machinery. The test suite asserts the two members of each pair
+produce identical trajectories from the same seed.
+
+## What the examples demonstrate
+
+The examples track the `worldtimer-adoption` line of ChronoSim and
+CompetingClocks 0.4, and exercise its new capabilities:
+
+* **The θ (parameter) seam.** An event's `enable` can take the parameter
+  vector explicitly — `enable(event, physical, θ, when)` — so a recorded
+  trajectory can be re-evaluated at any θ, including ForwardDiff dual numbers,
+  through `trace_likelihood(sim, init, trace; params=θ)`. The
+  [landspread](src/landspread/landspread.jl) model shows the recommended
+  four-argument style; the [reliability](src/reliability/reliability.jl) model
+  deliberately keeps the old three-argument signature to demonstrate that the
+  backward-compatible fallback works.
+* **Records and the effect check.** The
+  [repair shop](src/repairshop/repairshop.jl) example runs once under the
+  `RecordMinimal` policy to capture a `MinimalRecord`, verifies the record with
+  `effect_check` (replay must equal the forward log-likelihood exactly, `==`
+  not `≈`), and then differentiates the trace log-likelihood in θ with
+  ForwardDiff — the full record → check → differentiate workflow, tested
+  against a hand-derived analytic score in
+  [test/test_repairshop.jl](test/test_repairshop.jl).
+* **Master-seed, per-clock randomness.** Every random stream derives from one
+  seed, keyed by clock identity, so an event's draws do not depend on how other
+  events interleave. The elevator model documents the one sharp edge: a clock
+  key component needs a content-based `Base.hash` (see the `ElevatorDirection`
+  enum in [src/elevator/elevator.jl](src/elevator/elevator.jl)).
+* **Trigger derivation, over-approximation, and read verification.** The
+  hand-vs-derived twin tests run under ChronoSim's coverage oracle, and the
+  over-approximation tests measure the proposal cost of derived generators.
+
+For per-event coupling and memory declarations (`reevaluation_coupling`,
+`memory_policy`), simulation cloning, and forced firing, see the ChronoSim
+documentation; for keyed streams and sampler-level coupling guarantees, see the
+CompetingClocks documentation.
+
+## Migrating an existing model
+
+If you have a model written against ChronoSim with CompetingClocks 0.3, see
+[MIGRATION.md](MIGRATION.md). Most models need no code change; the document
+orders the cases by likelihood and includes before/after snippets from this
+repository's own migration.

--- a/README.md
+++ b/README.md
@@ -41,6 +41,18 @@ CompetingClocks 0.4, and exercise its new capabilities:
   ForwardDiff — the full record → check → differentiate workflow, tested
   against a hand-derived analytic score in
   [test/test_repairshop.jl](test/test_repairshop.jl).
+* **The gradient-estimator family.** The companion
+  [repair-shop gradients](src/repairshop/repairshop_gradients.jl) example runs
+  ClockGradients' whole family on the same law against one closed-form oracle:
+  the score/IPA pairing on a pure model (the pairing flags that the pathwise
+  estimate of a terminal count is identically zero), the branching estimator
+  driven through the live ChronoSim simulation, and smoothed perturbation
+  analysis (SPA) with the hand-written **pure model twin** the estimator
+  audits at every step. On this model SPA's criticality gate proves every
+  event-order swap harmless — independent machines commute — so it spawns no
+  clones and the whole derivative flows through its horizon boundary term.
+  Tested in
+  [test/test_repairshop_gradients.jl](test/test_repairshop_gradients.jl).
 * **Master-seed, per-clock randomness.** Every random stream derives from one
   seed, keyed by clock identity, so an event's draws do not depend on how other
   events interleave. The elevator model documents the one sharp edge: a clock

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -6,6 +6,14 @@ CurrentModule = ChronoSimExamples
 
 Documentation for [ChronoSimExamples](https://github.com/adolgert/ChronoSimExamples.jl).
 
+The repository README describes what each example demonstrates, including the
+θ (parameter) seam, trajectory records with the exact-replay effect check, and
+the repair-shop differentiation workflow. Users migrating a model from
+CompetingClocks 0.3 to 0.4 should read
+[MIGRATION.md](https://github.com/adolgert/ChronoSimExamples.jl/blob/main/MIGRATION.md)
+at the repository root, which orders the required changes by likelihood with
+before/after snippets.
+
 ```@index
 ```
 

--- a/src/ChronoSimExamples.jl
+++ b/src/ChronoSimExamples.jl
@@ -6,6 +6,7 @@ include("landspread/landspread.jl")
 include("reliability/reliability.jl")
 include("reliability/reliability_derived.jl")
 include("repairshop/repairshop.jl")
+include("repairshop/repairshop_gradients.jl")
 include("sirvillage/sirvillage.jl")
 include("sirvillage/sirvillage_derived.jl")
 

--- a/src/ChronoSimExamples.jl
+++ b/src/ChronoSimExamples.jl
@@ -5,6 +5,7 @@ include("elevator/elevator_derived.jl")
 include("landspread/landspread.jl")
 include("reliability/reliability.jl")
 include("reliability/reliability_derived.jl")
+include("repairshop/repairshop.jl")
 include("sirvillage/sirvillage.jl")
 include("sirvillage/sirvillage_derived.jl")
 

--- a/src/elevator/elevator.jl
+++ b/src/elevator/elevator.jl
@@ -23,6 +23,14 @@ import ChronoSim: precondition, enable, fire!, generators
 
 # DirectionState
 @enum ElevatorDirection Up Down Stationary
+# CompetingClocks 0.4 seeds each clock's random stream from `hash((seed, clock_key))`,
+# and DispatchElevator carries this enum inside its clock key. An enum has no
+# content-based `Base.hash`, so it falls back to `objectid`, which differs between
+# the twin modules that define the "same" enum and is not even stable across julia
+# processes with different compile options -- both reproducibility and the
+# hand-vs-derived trajectory identity break without this method. Hashing by the
+# value's name makes the clock key hash content-based and module-independent.
+Base.hash(x::ElevatorDirection, h::UInt) = hash(Symbol(x), h)
 
 @keyedby Person Int64 begin
     location::Int64  # a floor, 0 if on elevator.

--- a/src/elevator/elevator_derived.jl
+++ b/src/elevator/elevator_derived.jl
@@ -47,6 +47,14 @@ using ChronoSim.ObservedState
 import ChronoSim: precondition, enable, fire!, generators
 
 @enum ElevatorDirection Up Down Stationary
+# CompetingClocks 0.4 seeds each clock's random stream from `hash((seed, clock_key))`,
+# and DispatchElevator carries this enum inside its clock key. An enum has no
+# content-based `Base.hash`, so it falls back to `objectid`, which differs between
+# the twin modules that define the "same" enum and is not even stable across julia
+# processes with different compile options -- both reproducibility and the
+# hand-vs-derived trajectory identity break without this method. Hashing by the
+# value's name makes the clock key hash content-based and module-independent.
+Base.hash(x::ElevatorDirection, h::UInt) = hash(Symbol(x), h)
 
 @keyedby Person Int64 begin
     location::Int64

--- a/src/landspread/landspread.jl
+++ b/src/landspread/landspread.jl
@@ -54,18 +54,40 @@ end
         land.mark[evt.destination] == 0
 end
 
-function enable(evt::Spread, land, when)
+# This module is written against ChronoSim's θ (parameter) seam, the
+# four-argument form of `enable`: the simulation carries a parameter vector in
+# its `params` field (constructor keyword `params=`), and the engine passes it
+# to `enable` as the third argument. Reading the spread coefficients from θ
+# instead of hard-coding them means an estimator can re-evaluate this same
+# trace at a different θ — including a vector of ForwardDiff duals — through
+# the `params=` keyword of `trace_likelihood`, with no module-global state.
+# θ[1] is the scale coefficient and θ[2] the distance exponent of the Weibull
+# spread clock. Modules that still define the three-argument
+# `enable(evt, physical, when)` keep working: the four-argument default forwards
+# to it (see ReliabilitySim for a deliberate example of that fallback).
+const SPREAD_THETA = [0.1, 1.2]
+
+function enable(evt::Spread, land, θ, when)
     dist = land.distance[evt.source, evt.destination]
-    scale = 0.1 * dist^1.2
+    scale = θ[1] * dist^θ[2]
     return (Weibull(2, scale), when)
 end
 
+# NOTE the two-statement write idiom: the assignment happens as a plain
+# statement and `@obswrite` is applied to the ACCESS, only to record the
+# address. Passing the whole assignment to `@obswrite` looks natural but the
+# macro's assignment form drops the right-hand side (it records the address and
+# evaluates only the left-hand access), so the write never happens and the
+# simulation silently proposes nothing. That bug made this example run
+# zero events until the adoption audit caught it.
 @fire function fire!(evt::Spread, land, when, rng)
-    @obswrite land.mark[evt.destination] = 1
+    land.mark[evt.destination] = 1
+    @obswrite land.mark[evt.destination]
 end
 
 function init_physical!(land, when, rng)
-    @obswrite land.mark[1] = 1
+    land.mark[1] = 1
+    @obswrite land.mark[1]
 end
 
 struct TrajectoryEntry
@@ -86,7 +108,7 @@ function (te::TrajectorySave)(physical, when, event, changed_places)
     push!(te.trajectory, TrajectoryEntry(clock_key(event), when))
 end
 
-function run_landspread(point_cnt)
+function run_landspread(point_cnt; θ=SPREAD_THETA)
     rng = Xoshiro(9437294723)
     land = Landscape(point_cnt, rng)
     trajectory = TrajectorySave()
@@ -95,6 +117,7 @@ function run_landspread(point_cnt)
         [Spread];
         rng = rng,
         observer = trajectory,
+        params = θ,
         )
     stop_condition = function(land, step, event, when)
         return false
@@ -104,7 +127,12 @@ function run_landspread(point_cnt)
 end
 
 
-function landspread_likelihood(point_cnt)
+# Evaluate the recorded trajectory's log-likelihood at an explicit θ. Because θ
+# arrives through the `params=` keyword rather than through anything the model
+# module owns, the same trace can be scored at the θ that generated it, at a
+# perturbed θ, or at a dual-valued θ for automatic differentiation — see the
+# RepairShop module for that workflow taken through ForwardDiff.
+function landspread_likelihood(point_cnt; θ=SPREAD_THETA)
     trajectory_vector = run_landspread(point_cnt)
     event_dict = Dict(:Spread => Spread, :InitializeEvent => ChronoSim.InitializeEvent)
     event_vector = [astuple(te, event_dict) for te in trajectory_vector]
@@ -117,10 +145,14 @@ function landspread_likelihood(point_cnt)
         [Spread];
         sampler = NextReactionMethod(), key_type = Tuple,
         step_likelihood = true,
+        likelihood_eltype = eltype(θ),
         rng = rng
         )
-    how_likely = ChronoSim.trace_likelihood(sim, init_physical!, event_vector).loglikelihood
+    how_likely = ChronoSim.trace_likelihood(
+        sim, init_physical!, event_vector; params=θ
+    ).loglikelihood
     println("logpdf $how_likely")
+    return how_likely
 end
 end  # module LandSpread
 

--- a/src/reliability/reliability.jl
+++ b/src/reliability/reliability.jl
@@ -58,6 +58,13 @@ struct StartDay <: SimEvent end
     end
 end
 
+# This module DELIBERATELY keeps the pre-θ-seam three-argument enable
+# signature, `enable(event, physical, when)`. ChronoSim's engine now calls the
+# four-argument θ-seam form, `enable(event, physical, θ, when)`, and its default
+# method forwards to this one, so a model that reads no parameters from θ needs
+# no change. This module (and its ReliabilityDerivedSim twin) is the suite's
+# standing evidence that the fallback works; see LandSpread for the recommended
+# four-argument style.
 function enable(evt::StartDay, physical, when)
     desired_time = floor(when) + 1.0 + physical.start_time
     interval = desired_time - when

--- a/src/repairshop/repairshop.jl
+++ b/src/repairshop/repairshop.jl
@@ -1,0 +1,193 @@
+# RepairShop: an end-to-end differentiation workflow on a machine-repair model.
+#
+# This example shows the three-step pattern that ChronoSim's record/replay
+# machinery exists to support:
+#
+#   1. RUN a simulation once with the `RecordMinimal` execution policy, which
+#      captures a `MinimalRecord` — the initializer, the ordered (clock key,
+#      firing time) sequence, the horizon, and a flag saying whether any `fire!`
+#      body drew randomness.
+#   2. CHECK the record with `effect_check`, which replays it through
+#      `trace_likelihood` and demands EXACT floating-point equality with the
+#      log-likelihood the forward run accumulated. Exact equality (not ≈) is the
+#      point: forward execution and trace evaluation share one code path, so any
+#      difference is a bug, not roundoff.
+#   3. DIFFERENTIATE by evaluating `trace_likelihood` at a θ the forward run
+#      never saw — here a vector of `ForwardDiff.Dual` numbers — to get the
+#      score (the gradient of the trace log-likelihood in the parameters). The
+#      θ (parameter) seam makes this possible: each event's four-argument
+#      `enable(event, physical, θ, when)` builds its distribution from the θ the
+#      caller supplies, so no global state changes between evaluations.
+#
+# The model: `machine_cnt` machines run until they break down and are repaired.
+# Both clocks are exponential; θ = [breakdown rate, repair rate]. Exponential
+# clocks keep the analytic score simple enough to verify by hand in the test
+# suite (`test/test_repairshop.jl`), which is what makes this example an
+# oracle-checked demonstration rather than a demo that merely runs.
+
+module RepairShop
+
+using ChronoSim
+using ChronoSim.ObservedState
+using CompetingClocks
+using Distributions
+using ForwardDiff
+using Random
+import ChronoSim: generators, precondition, enable, fire!
+
+export record_repair_shop, repair_shop_loglik, repair_shop_score, repair_shop_demo
+
+@enum MachineCondition running down
+
+@keyedby Machine Int64 begin
+    condition::MachineCondition
+end
+
+@observedphysical Shop begin
+    machines::ObservedVector{Machine,Member}
+end
+
+function Shop(machine_cnt::Int)
+    machines = ObservedArray{Machine,Member}(undef, machine_cnt)
+    for i in 1:machine_cnt
+        machines[i] = Machine(running)
+    end
+    return Shop(machines)
+end
+
+# The initializer writes every machine's condition so the write notifications
+# propose the initial Breakdown events. `RecordMinimal` stores this function in
+# the record, so a replay reconstructs the same initial state.
+function init!(shop, when, rng)
+    for i in eachindex(shop.machines)
+        shop.machines[i].condition = running
+    end
+end
+
+struct Breakdown <: SimEvent
+    machine::Int64
+end
+
+@conditionsfor Breakdown begin
+    @reactto changed(machines[m].condition) do shop
+        generate(Breakdown(m))
+    end
+end
+
+@guard precondition(evt::Breakdown, shop) =
+    shop.machines[evt.machine].condition == running
+
+# The four-argument θ seam: the breakdown rate is θ[1], read at enable time from
+# the parameter vector the simulation carries. Distributions.jl's Exponential
+# takes a scale, so rate θ[1] becomes Exponential(inv(θ[1])); when θ is a vector
+# of ForwardDiff duals, `inv` promotes and the dual flows into the distribution.
+enable(evt::Breakdown, shop, θ, when) = (Exponential(inv(θ[1])), when)
+
+@fire function fire!(evt::Breakdown, shop, when, rng)
+    shop.machines[evt.machine].condition = down
+end
+
+struct Repair <: SimEvent
+    machine::Int64
+end
+
+@conditionsfor Repair begin
+    @reactto changed(machines[m].condition) do shop
+        generate(Repair(m))
+    end
+end
+
+@guard precondition(evt::Repair, shop) =
+    shop.machines[evt.machine].condition == down
+
+# The repair rate is θ[2].
+enable(evt::Repair, shop, θ, when) = (Exponential(inv(θ[2])), when)
+
+@fire function fire!(evt::Repair, shop, when, rng)
+    shop.machines[evt.machine].condition = running
+end
+
+_events() = [Breakdown, Repair]
+
+"""
+    record_repair_shop(θ; machine_cnt=3, horizon=20.0, seed=90210)
+
+Run the repair shop once at parameters `θ = [breakdown_rate, repair_rate]` with
+the `RecordMinimal` policy and return `(record, policy)`: the `MinimalRecord`
+of the run (with its horizon, for censored evaluation) and the policy object
+(which `effect_check` consumes). One master `seed` determines the whole
+trajectory — CompetingClocks 0.4 derives every per-clock random stream from it.
+"""
+function record_repair_shop(θ; machine_cnt::Int=3, horizon::Float64=20.0, seed=90210)
+    policy = RecordMinimal(; initializer=init!)
+    sim = SimulationFSM(
+        Shop(machine_cnt), _events();
+        seed=seed, sampler=NextReactionMethod(), key_type=Tuple,
+        step_likelihood=true, policy=policy, params=θ,
+    )
+    stop_condition = (physical, step_idx, event, when) -> when > horizon
+    ChronoSim.run(sim, init!, stop_condition)
+    return (record=minimal_record(policy; horizon=horizon), policy=policy)
+end
+
+"""
+    repair_shop_loglik(θ, record; machine_cnt=3)
+
+The log-likelihood of a recorded trajectory evaluated at an explicit `θ`.
+`censor=true` adds the finite-horizon survival tail (no clock fired between the
+last event and the record's horizon), so the value covers the whole observation
+window, not just the firings. A FRESH evaluation simulation is built per call:
+a `SimulationFSM` cannot currently evaluate two traces back to back, so the
+closure-over-a-fresh-sim pattern is the supported one. `eltype(θ)` is passed as
+the likelihood element type so ForwardDiff dual numbers accumulate without
+truncation.
+"""
+function repair_shop_loglik(θ, record; machine_cnt::Int=3)
+    sim = SimulationFSM(
+        Shop(machine_cnt), _events();
+        seed=1, sampler=NextReactionMethod(), key_type=Tuple,
+        step_likelihood=true, likelihood_eltype=eltype(θ),
+    )
+    return trace_likelihood(sim, init!, record; params=θ, censor=true).loglikelihood
+end
+
+"""
+    repair_shop_score(θ, record; machine_cnt=3)
+
+The score — the gradient of the recorded trajectory's log-likelihood in θ —
+computed by running `ForwardDiff.gradient` through `repair_shop_loglik`. The
+trace is FIXED; only the parameters at which it is scored vary, which is why
+the result is a deterministic function of `(θ, record)`.
+"""
+function repair_shop_score(θ, record; machine_cnt::Int=3)
+    return ForwardDiff.gradient(
+        p -> repair_shop_loglik(p, record; machine_cnt=machine_cnt), θ
+    )
+end
+
+"""
+    repair_shop_demo(; θ=[0.3, 1.0], machine_cnt=3, horizon=20.0, seed=90210)
+
+The whole workflow in one call: record a trajectory at `θ`, evaluate its
+log-likelihood, and print the score at the generating parameters. Returns
+`(record, loglikelihood, score)`.
+"""
+function repair_shop_demo(; θ=[0.3, 1.0], machine_cnt::Int=3, horizon::Float64=20.0,
+                          seed=90210)
+    (; record, policy) = record_repair_shop(
+        θ; machine_cnt=machine_cnt, horizon=horizon, seed=seed
+    )
+    ll = repair_shop_loglik(θ, record; machine_cnt=machine_cnt)
+    g = repair_shop_score(θ, record; machine_cnt=machine_cnt)
+    println("recorded $(length(record.firings)) firings over horizon $(record.horizon)")
+    println("log-likelihood at θ=$(θ): $(ll)")
+    println("score (dloglik/dθ) at θ=$(θ): $(g)")
+    return (record=record, loglikelihood=ll, score=g)
+end
+
+end # module RepairShop
+
+if abspath(PROGRAM_FILE) == @__FILE__
+    using .RepairShop
+    repair_shop_demo()
+end

--- a/src/repairshop/repairshop_gradients.jl
+++ b/src/repairshop/repairshop_gradients.jl
@@ -1,0 +1,188 @@
+# RepairShopGradients: the estimator family on one model.
+#
+# `repairshop.jl` demonstrates the SCORE path: record a trajectory, replay its
+# likelihood at a dual θ. This companion demonstrates the rest of the
+# ClockGradients estimator family on the same law, all against one closed-form
+# oracle:
+#
+#   * the score/IPA PAIRING (`paired_simulate_and_estimate`) on the pure model,
+#     which flags that the pathwise estimator is identically zero for a
+#     terminal count while the score recovers the truth;
+#   * the BRANCHING estimator (`branching_gradient`) driven through the live
+#     ChronoSim simulation via the ClockGradients–ChronoSim extension;
+#   * SMOOTHED PERTURBATION ANALYSIS (`spa_gradient`) through the same live
+#     simulation, which needs one extra ingredient — the PURE MODEL TWIN
+#     defined below — and shows off its criticality gate: this shop's machines
+#     are independent, so EVERY event-order swap provably commutes, the gate
+#     spawns no clones at all, and the whole derivative flows through SPA's
+#     horizon boundary term (machines crossing into the observation window).
+#
+# The functional is the number of down machines at the horizon. Each machine is
+# an independent two-state Markov chain (up →(λ) down →(μ) up), so
+#
+#     E[#down(T)] = n · (λ/(λ+μ)) · (1 − exp(−(λ+μ)T))
+#
+# in closed form, and ForwardDiff through it gives the exact gradient oracle.
+#
+# THE PURE MODEL TWIN. SPA replays records and speculatively fires event pairs,
+# so it needs the law as a pure five-function ClockGradients model whose clock
+# keys match ChronoSim's `clock_key` convention — (:Breakdown, m) and
+# (:Repair, m) here. The estimator audits the twin's enabled set against the
+# live simulation's at every step and stops with a named error on the first
+# disagreement, so the hand-written duplication cannot silently drift.
+
+module RepairShopGradients
+
+using ChronoSim
+using CompetingClocks: NextReactionMethod
+using ClockGradients
+using ClockGradients: TerminalObservable
+using Distributions
+using ForwardDiff
+using Random: Xoshiro
+import ClockGradients: initial_state, clockkeytype, enabled, clock_distribution, fire
+
+using ..RepairShop: RepairShop
+
+export ShopLaw, expected_down, expected_down_gradient,
+    repair_shop_pairing, repair_shop_branching, repair_shop_spa,
+    repair_shop_gradients_demo
+
+# --- the pure model twin -------------------------------------------------------
+
+struct ShopLawState
+    down::Vector{Bool}
+end
+# Value equality is what lets SPA's criticality gate recognize commuting swaps;
+# the default == on a struct with an array field is identity, which would
+# silently disable the gate.
+Base.:(==)(a::ShopLawState, b::ShopLawState) = a.down == b.down
+
+"""
+    ShopLaw(machine_cnt)
+
+The repair shop as a pure ClockGradients model: `machine_cnt` machines, each
+breaking down at rate `θ[1]` and being repaired at rate `θ[2]`, with clock
+keys matching the ChronoSim model's `clock_key` convention.
+"""
+struct ShopLaw
+    machine_cnt::Int
+end
+initial_state(m::ShopLaw) = ShopLawState(fill(false, m.machine_cnt))
+clockkeytype(::ShopLaw) = Tuple
+function enabled(m::ShopLaw, s::ShopLawState)
+    ks = Tuple[]
+    for i in 1:m.machine_cnt
+        push!(ks, s.down[i] ? (:Repair, i) : (:Breakdown, i))
+    end
+    ks
+end
+clock_distribution(::ShopLaw, θ, key::Tuple) =
+    key[1] === :Breakdown ? Exponential(one(eltype(θ)) / θ[1]) :
+                            Exponential(one(eltype(θ)) / θ[2])
+function fire(::ShopLaw, s::ShopLawState, key::Tuple)
+    down = copy(s.down)
+    down[key[2]] = key[1] === :Breakdown
+    ShopLawState(down)
+end
+
+# The functional on the twin's states and on the live physical state.
+ndown_twin(s::ShopLawState) = count(s.down)
+ndown_physical(shop) =
+    count(shop.machines[i].condition == RepairShop.down
+          for i in eachindex(shop.machines))
+
+# --- the closed-form oracle -----------------------------------------------------
+
+"""
+    expected_down(θ, machine_cnt, horizon)
+
+Exact `E[#down(horizon)]` starting all-up: each machine is an independent
+two-state chain, so the down probability is `(λ/(λ+μ))(1 − exp(−(λ+μ)T))`.
+"""
+function expected_down(θ, machine_cnt::Integer, horizon::Real)
+    λ, μ = θ[1], θ[2]
+    machine_cnt * (λ / (λ + μ)) * (1 - exp(-(λ + μ) * horizon))
+end
+
+expected_down_gradient(θ, machine_cnt::Integer, horizon::Real) =
+    ForwardDiff.gradient(p -> expected_down(p, machine_cnt, horizon), collect(float.(θ)))
+
+# --- the estimators, one call each ------------------------------------------------
+
+# A fresh live simulation at params = θ; the estimators reseed every replication.
+_sim_factory(θ, machine_cnt) = () -> SimulationFSM(
+    RepairShop.Shop(machine_cnt), [RepairShop.Breakdown, RepairShop.Repair];
+    seed=UInt64(1), sampler=NextReactionMethod(), key_type=Tuple, params=θ)
+
+"""
+    repair_shop_pairing(θ; machine_cnt=3, horizon=8.0, nreps=4000, seed=2028)
+
+The score/IPA pairing on the pure model: for the terminal down-count the
+pathwise estimate is identically zero (a frozen discrete read), the score
+recovers the oracle, and the pairing flags the bias.
+"""
+repair_shop_pairing(θ; machine_cnt::Int=3, horizon::Float64=8.0,
+                    nreps::Int=4000, seed::Int=2028) =
+    paired_simulate_and_estimate(Xoshiro(seed), ShopLaw(machine_cnt),
+                                 collect(float.(θ)), NextReactionMethod(),
+                                 TerminalObservable(ndown_twin);
+                                 nreps=nreps, horizon=horizon)
+
+"""
+    repair_shop_branching(θ; machine_cnt=3, horizon=8.0, nreps=800, seed=2029)
+
+The weak-derivative branching estimator through the LIVE ChronoSim simulation
+(the ClockGradients–ChronoSim extension supplies the branchable-world verbs).
+"""
+repair_shop_branching(θ; machine_cnt::Int=3, horizon::Float64=8.0,
+                      nreps::Int=800, seed::Int=2029) =
+    branching_gradient(_sim_factory(collect(float.(θ)), machine_cnt),
+                       RepairShop.init!, collect(float.(θ)), ndown_physical;
+                       nreps=nreps, horizon=horizon, seed=seed,
+                       branch_rng_seed=seed + 1)
+
+"""
+    repair_shop_spa(θ; machine_cnt=3, horizon=8.0, nreps=4000, seed=2030)
+
+Smoothed perturbation analysis through the live ChronoSim simulation with
+`ShopLaw` as the pure model twin. On this model the criticality gate proves
+every event-order swap harmless (independent machines commute), so the
+estimator spawns NO clones and the whole derivative is its horizon boundary
+term — check `skip_fraction == 1.0` and `clones_per_rep == 0.0` in the result.
+
+An honest caveat this example makes visible: with no order effects to recover,
+SPA has no advantage here — the plain score estimate is several times tighter
+per replication. SPA earns its keep on functionals whose derivative is carried
+by event ORDER (queueing counts, contended first passage); this model
+demonstrates its gate and horizon machinery, not its best-case variance.
+"""
+repair_shop_spa(θ; machine_cnt::Int=3, horizon::Float64=8.0,
+                nreps::Int=4000, seed::Int=2030) =
+    spa_gradient(_sim_factory(collect(float.(θ)), machine_cnt),
+                 RepairShop.init!, ShopLaw(machine_cnt), collect(float.(θ)),
+                 TerminalObservable(ndown_twin);
+                 nreps=nreps, horizon=horizon, seed=seed)
+
+"""
+    repair_shop_gradients_demo(; θ=[0.3, 1.0], machine_cnt=3, horizon=8.0)
+
+Run the family and print every estimate against the closed-form oracle.
+"""
+function repair_shop_gradients_demo(; θ=[0.3, 1.0], machine_cnt::Int=3,
+                                    horizon::Float64=8.0)
+    oracle = expected_down_gradient(θ, machine_cnt, horizon)
+    println("oracle dE[#down(T)]/dθ = $(oracle)")
+    pair = repair_shop_pairing(θ; machine_cnt=machine_cnt, horizon=horizon)
+    println("score = $(pair.score) ± $(pair.score_stderr); IPA = $(pair.ipa) " *
+            "(pinned zero); bias flagged: $(pair.bias_detected)")
+    br = repair_shop_branching(θ; machine_cnt=machine_cnt, horizon=horizon)
+    println("branching = $(br.estimate) ± $(br.stderr) " *
+            "($(br.clones_per_rep) clones/rep)")
+    spa = repair_shop_spa(θ; machine_cnt=machine_cnt, horizon=horizon)
+    println("SPA = $(spa.estimate) ± $(spa.stderr) " *
+            "(skip fraction $(spa.skip_fraction), $(spa.clones_per_rep) clones/rep)")
+    return (oracle=oracle, pairing=pair, branching=br, spa=spa)
+end
+
+end # module RepairShopGradients

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -6,6 +6,7 @@ continuous_integration() = get(ENV, "CI", "false") == "true"
 include("test_elevator.jl")
 include("test_reliability.jl")
 include("test_repairshop.jl")
+include("test_repairshop_gradients.jl")
 include("test_landspread.jl")
 include("test_sirvillage.jl")
 include("test_differential.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5,6 +5,8 @@ continuous_integration() = get(ENV, "CI", "false") == "true"
 
 include("test_elevator.jl")
 include("test_reliability.jl")
+include("test_repairshop.jl")
+include("test_landspread.jl")
 include("test_sirvillage.jl")
 include("test_differential.jl")
 include("test_invariants.jl")

--- a/test/test_landspread.jl
+++ b/test/test_landspread.jl
@@ -1,0 +1,32 @@
+# Landspread previously had no functional test, which is how a silent
+# no-write bug (an @obswrite assignment whose right-hand side the macro
+# discarded) left it running zero events without anyone noticing. These tests
+# pin that the process actually spreads and that the θ seam evaluates the same
+# trace at different parameters.
+
+using Logging
+using Test
+
+using ChronoSimExamples: LandSpread
+
+@testset "landspread spreads from the seed point to every point" begin
+    traj = with_logger(ConsoleLogger(stderr, Logging.Warn)) do
+        LandSpread.run_landspread(10)
+    end
+    # One InitializeEvent plus one Spread firing per remaining point: the
+    # process is monotone (marks never clear), so it must saturate.
+    @test length(traj) == 10
+    @test count(te -> te.event[1] == :Spread, traj) == 9
+end
+
+@testset "landspread trace log-likelihood is finite and moves with θ through the seam" begin
+    ll, ll_shifted = with_logger(ConsoleLogger(stderr, Logging.Warn)) do
+        (LandSpread.landspread_likelihood(10),
+         LandSpread.landspread_likelihood(10; θ=[0.2, 1.0]))
+    end
+    @test isfinite(ll)
+    @test isfinite(ll_shifted)
+    # Same recorded trace, different θ: the evaluation must respond to the
+    # parameters, which is the θ-seam property estimators rely on.
+    @test ll != ll_shifted
+end

--- a/test/test_repairshop.jl
+++ b/test/test_repairshop.jl
@@ -1,0 +1,96 @@
+# The RepairShop example is the package's end-to-end differentiation workflow:
+# record a trajectory with RecordMinimal, verify the record with effect_check's
+# exact-equality replay, then evaluate trace_likelihood at a dual-valued θ with
+# ForwardDiff to get the score. Exponential clocks make the score analytic, so
+# the ForwardDiff gradient is compared against a hand-derived oracle computed by
+# walking the record, not against another autodiff.
+
+using ChronoSim
+using CompetingClocks
+using Test
+
+using ChronoSimExamples: RepairShop
+
+# The analytic score of a censored exponential-clock trajectory. For competing
+# exponential clocks the trace log-likelihood is
+#   loglik = n_break·log(λ_b) + n_repair·log(λ_r) − λ_b·E_run − λ_r·E_down
+# where E_run is the total machine-time spent running (each running machine has
+# an enabled Breakdown clock at rate λ_b) and E_down the total machine-time
+# spent down, both accumulated over the FULL window [0, horizon] because the
+# evaluation is censored. Hence dloglik/dλ_b = n_break/λ_b − E_run and
+# dloglik/dλ_r = n_repair/λ_r − E_down. The exposures come from replaying the
+# record's firing sequence: every machine starts running, Breakdown flips one
+# machine down, Repair flips it back.
+function analytic_score(θ, record, machine_cnt)
+    n_running = machine_cnt
+    n_break = 0
+    n_repair = 0
+    e_run = 0.0
+    e_down = 0.0
+    prev = 0.0
+    for (ck, when) in record.firings
+        e_run += n_running * (when - prev)
+        e_down += (machine_cnt - n_running) * (when - prev)
+        if ck[1] == :Breakdown
+            n_running -= 1
+            n_break += 1
+        elseif ck[1] == :Repair
+            n_running += 1
+            n_repair += 1
+        else
+            error("unexpected clock key $ck")
+        end
+        prev = when
+    end
+    # The censoring tail: exposure continues from the last firing to the horizon.
+    e_run += n_running * (record.horizon - prev)
+    e_down += (machine_cnt - n_running) * (record.horizon - prev)
+    return [n_break / θ[1] - e_run, n_repair / θ[2] - e_down]
+end
+
+@testset "repairshop: the recorded trajectory is deterministic, draw-free, and long enough to test" begin
+    θ = [0.3, 1.0]
+    (; record, policy) = RepairShop.record_repair_shop(θ; machine_cnt=3, horizon=20.0, seed=90210)
+    # fire! bodies draw no randomness, so the firing sequence is a deterministic
+    # function of the initial state and the record is trustworthy for replay.
+    @test record.fire_random == false
+    @test record.horizon == 20.0
+    # Enough events that the score test below is not vacuous.
+    @test length(record.firings) > 10
+    # The same seed reproduces the identical record (master-seed determinism).
+    again = RepairShop.record_repair_shop(θ; machine_cnt=3, horizon=20.0, seed=90210)
+    @test again.record.firings == record.firings
+end
+
+@testset "repairshop: effect_check replays the record to the exact forward log-likelihood" begin
+    θ = [0.3, 1.0]
+    (; record, policy) = RepairShop.record_repair_shop(θ; machine_cnt=3, horizon=20.0, seed=90210)
+    factory = () -> SimulationFSM(
+        RepairShop.Shop(3), [RepairShop.Breakdown, RepairShop.Repair];
+        seed=1, sampler=NextReactionMethod(), key_type=Tuple,
+        step_likelihood=true, params=θ,
+    )
+    res = ChronoSim.effect_check(factory, RepairShop.init!, policy)
+    @test res.applicable
+    @test res.passed
+    # Exact Float64 identity: forward accumulation and replay share a code path.
+    @test res.forward === res.replay
+    @test isfinite(res.forward)
+end
+
+@testset "repairshop: the ForwardDiff score of the censored trace matches the analytic exponential score" begin
+    θ = [0.3, 1.0]
+    machine_cnt = 3
+    (; record, policy) = RepairShop.record_repair_shop(
+        θ; machine_cnt=machine_cnt, horizon=20.0, seed=90210
+    )
+    g = RepairShop.repair_shop_score(θ, record; machine_cnt=machine_cnt)
+    oracle = analytic_score(θ, record, machine_cnt)
+    @test isapprox(g, oracle; rtol=1e-9)
+    # The score is also correct away from the generating θ — the trace is fixed,
+    # only the evaluation parameters move. This is the property estimators lean on.
+    θ2 = [0.5, 0.7]
+    g2 = RepairShop.repair_shop_score(θ2, record; machine_cnt=machine_cnt)
+    oracle2 = analytic_score(θ2, record, machine_cnt)
+    @test isapprox(g2, oracle2; rtol=1e-9)
+end

--- a/test/test_repairshop_gradients.jl
+++ b/test/test_repairshop_gradients.jl
@@ -1,0 +1,61 @@
+# The estimator family on the repair shop, each against the closed-form
+# oracle E[#down(T)] = n·(λ/(λ+μ))·(1 − exp(−(λ+μ)T)). Statistical acceptance
+# follows the WorldTimer convention: fixed seeds, agreement within four
+# standard errors, and a standard-error smallness guard so the comparison
+# bites.
+
+using Test
+using ChronoSimExamples.RepairShopGradients
+using ChronoSimExamples.RepairShopGradients: ndown_twin, ShopLawState
+
+const _RSG_θ = [0.3, 1.0]
+const _RSG_N = 3
+const _RSG_T = 8.0
+
+@testset "repairshop gradients: the closed-form oracle matches a direct check at the test parameters" begin
+    # n·(λ/(λ+μ))·(1−e^{−(λ+μ)T}) differentiated by hand at λ=0.3, μ=1.0:
+    # cross-check the ForwardDiff oracle against finite differences.
+    g = expected_down_gradient(_RSG_θ, _RSG_N, _RSG_T)
+    h = 1e-6
+    for j in 1:2
+        θp = copy(_RSG_θ); θp[j] += h
+        θm = copy(_RSG_θ); θm[j] -= h
+        fd = (expected_down(θp, _RSG_N, _RSG_T) - expected_down(θm, _RSG_N, _RSG_T)) / 2h
+        @test abs(g[j] - fd) < 1e-6
+    end
+end
+
+@testset "repairshop gradients: the pairing flags the pathwise zero and the score recovers the oracle" begin
+    oracle = expected_down_gradient(_RSG_θ, _RSG_N, _RSG_T)
+    pair = repair_shop_pairing(_RSG_θ)
+    for j in 1:2
+        @test pair.ipa[j] == 0.0                       # frozen discrete read
+        @test abs(pair.score[j] - oracle[j]) < 4 * pair.score_stderr[j]
+        @test pair.score_stderr[j] < abs(oracle[j]) / 5
+    end
+    @test any(pair.bias_detected)
+end
+
+@testset "repairshop gradients: branching through the live ChronoSim simulation matches the oracle" begin
+    oracle = expected_down_gradient(_RSG_θ, _RSG_N, _RSG_T)
+    br = repair_shop_branching(_RSG_θ)
+    for j in 1:2
+        @test abs(br.estimate[j] - oracle[j]) < 4 * br.stderr[j]
+        @test br.stderr[j] < abs(oracle[j]) / 4
+    end
+end
+
+@testset "repairshop gradients: SPA proves every swap harmless on independent machines and carries the derivative in its horizon term" begin
+    oracle = expected_down_gradient(_RSG_θ, _RSG_N, _RSG_T)
+    spa = repair_shop_spa(_RSG_θ)
+    for j in 1:2
+        @test abs(spa.estimate[j] - oracle[j]) < 4 * spa.stderr[j]
+        @test spa.stderr[j] < abs(oracle[j]) / 5
+    end
+    # Independent machines: the criticality gate certifies every candidate
+    # pair, no clone is ever spawned, and the pathwise part is identically
+    # zero — the whole estimate is horizon crossings.
+    @test spa.skip_fraction == 1.0
+    @test spa.clones_per_rep == 0.0
+    @test spa.ipa_part == [0.0, 0.0]
+end

--- a/test/whyverbs_elevator_nobutton.jl
+++ b/test/whyverbs_elevator_nobutton.jl
@@ -58,6 +58,14 @@ using ChronoSim.ObservedState
 import ChronoSim: precondition, enable, fire!, generators
 
 @enum ElevatorDirection Up Down Stationary
+# CompetingClocks 0.4 seeds each clock's random stream from `hash((seed, clock_key))`,
+# and DispatchElevator carries this enum inside its clock key. An enum has no
+# content-based `Base.hash`, so it falls back to `objectid`, which differs between
+# the twin modules that define the "same" enum and is not even stable across julia
+# processes with different compile options -- both reproducibility and the
+# hand-vs-derived trajectory identity break without this method. Hashing by the
+# value's name makes the clock key hash content-based and module-independent.
+Base.hash(x::ElevatorDirection, h::UInt) = hash(Symbol(x), h)
 
 @keyedby Person Int64 begin
     location::Int64

--- a/test/whyverbs_elevator_stopbug.jl
+++ b/test/whyverbs_elevator_stopbug.jl
@@ -24,6 +24,14 @@ import ChronoSim: precondition, enable, fire!, generators
 
 # DirectionState
 @enum ElevatorDirection Up Down Stationary
+# CompetingClocks 0.4 seeds each clock's random stream from `hash((seed, clock_key))`,
+# and DispatchElevator carries this enum inside its clock key. An enum has no
+# content-based `Base.hash`, so it falls back to `objectid`, which differs between
+# the twin modules that define the "same" enum and is not even stable across julia
+# processes with different compile options -- both reproducibility and the
+# hand-vs-derived trajectory identity break without this method. Hashing by the
+# value's name makes the clock key hash content-based and module-independent.
+Base.hash(x::ElevatorDirection, h::UInt) = hash(Symbol(x), h)
 
 @keyedby Person Int64 begin
     location::Int64  # a floor, 0 if on elevator.


### PR DESCRIPTION
Migrates the examples onto the CompetingClocks 0.4 sampler and the ChronoSim parameter seam, and adds a gradient-oriented example.

## Highlights
- **Repair-shop gradients:** the whole estimator family checked against one closed-form oracle (new `repairshop.jl` + `repairshop_gradients.jl`).
- **Migrate to CompetingClocks 0.4 and the ChronoSim parameter seam** across the existing examples (elevator, landspread, reliability).
- Docs: `MIGRATION.md` and README updates for the new capabilities.

## Scope
18 files changed (+980 / -15), including new repair-shop example and tests plus `Project.toml`/`Manifest.toml` bumps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)